### PR TITLE
Fix bootstrap and dist config paths

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -24,15 +24,15 @@ class BuildkiteAgent < Formula
   def agent_token
     ARGV.value("token") || default_agent_token
   end
-  
+
   def agent_etc
     etc/"buildkite-agent"
   end
-  
+
   def agent_share
     share/"buildkite-agent"
   end
-  
+
   def agent_var
     var/"buildkite-agent"
   end
@@ -59,7 +59,7 @@ class BuildkiteAgent < Formula
 
   def install
     bin.mkpath
-    
+
     agent_etc.mkpath
     agent_var.mkpath
     agent_share.mkpath
@@ -155,6 +155,10 @@ class BuildkiteAgent < Formula
       your current user. It's also recommended to install Caffeine
       (http://lightheadsw.com/caffeine/) to prevent your machine from going to
       sleep or logging out.
+
+      To run multiple agents simply run the buildkite-agent start command
+      multiple times, or duplicate the LaunchAgent plist to create another
+      that starts on login.
     EOS
   end
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -24,34 +24,50 @@ class BuildkiteAgent < Formula
   def agent_token
     ARGV.value("token") || default_agent_token
   end
+  
+  def agent_etc
+    etc/"buildkite-agent"
+  end
+  
+  def agent_share
+    share/"buildkite-agent"
+  end
+  
+  def agent_var
+    var/"buildkite-agent"
+  end
 
   def agent_hooks_path
-    etc/"buildkite-agent/hooks"
+    agent_etc/"hooks"
   end
 
   def agent_builds_path
-    var/"buildkite-agent/builds"
+    agent_var/"builds"
   end
 
   def agent_bootstrap_path
-    etc/"bootstrap.sh"
+    agent_etc/"bootstrap.sh"
   end
 
   def agent_config_path
-    etc/"buildkite-agent/buildkite-agent.cfg"
+    agent_etc/"buildkite-agent.cfg"
   end
 
   def agent_config_dist_path
-    share/"buildkite-agent.dist.cfg"
+    agent_share/"buildkite-agent.dist.cfg"
   end
 
   def install
     bin.mkpath
+    
+    agent_etc.mkpath
+    agent_var.mkpath
+    agent_share.mkpath
     agent_hooks_path.mkpath
     agent_builds_path.mkpath
 
     agent_hooks_path.install Dir["hooks/*"]
-    etc.install "bootstrap.sh"
+    agent_etc.install "bootstrap.sh"
 
     agent_config_dist_path.write(default_config_file)
 


### PR DESCRIPTION
We've been incorrectly installing the config to `/usr/local/etc/buildkite-agent.cfg` instead of `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`, and installing the dist version of the cfg to `/usr/local/share/buildkite-agent.cfg` instead of `/usr/local/share/buildkite-agent/buildkite-agent.cfg`.

This fixes both of these, and adds instructions for running multiple instances of the agent.