### PR TITLE
Fix printing caveats, and a million nitpicks

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -182,6 +182,8 @@ class BuildkiteAgent < Formula
   end
 
   def agent_token_reminder
+    return "" unless agent_config_path.exist?
+
     if agent_config_path.read.include?(default_agent_token)
       "\n      \n      \033[31mDon't forget to update your configuration file with your agent token\033[0m"
     end

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -28,10 +28,6 @@ class BuildkiteAgent < Formula
     etc/"buildkite-agent"
   end
 
-  def agent_share
-    share/"buildkite-agent"
-  end
-
   def agent_var
     var/"buildkite-agent"
   end
@@ -61,7 +57,7 @@ class BuildkiteAgent < Formula
   end
 
   def agent_config_dist_path
-    agent_share/"buildkite-agent.dist.cfg"
+    pkgshare/"buildkite-agent.dist.cfg"
   end
 
   def install
@@ -69,7 +65,7 @@ class BuildkiteAgent < Formula
 
     agent_etc.mkpath
     agent_var.mkpath
-    agent_share.mkpath
+    pkgshare.mkpath
     agent_hooks_path.mkpath
     agent_builds_path.mkpath
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -91,12 +91,12 @@ class BuildkiteAgent < Formula
   end
 
   def default_config_file(agent_token = default_agent_token)
-    File.read("buildkite-agent.cfg").
-      gsub(/token=.+/, "token=\"#{agent_token}\"").
-      gsub(/bootstrap-script=.+/, "bootstrap-script=\"#{agent_bootstrap_path}\"").
-      gsub(/build-path=.+/, "build-path=\"#{agent_builds_path}\"").
-      gsub(/hooks-path=.+/, "hooks-path=\"#{agent_hooks_path}\"").
-      gsub(/plugins-path=.+/, "plugins-path=\"#{agent_plugins_path}\"")
+    File.read("buildkite-agent.cfg")
+        .gsub(/token=.+/, "token=\"#{agent_token}\"")
+        .gsub(/bootstrap-script=.+/, "bootstrap-script=\"#{agent_bootstrap_path}\"")
+        .gsub(/build-path=.+/, "build-path=\"#{agent_builds_path}\"")
+        .gsub(/hooks-path=.+/, "hooks-path=\"#{agent_hooks_path}\"")
+        .gsub(/plugins-path=.+/, "plugins-path=\"#{agent_plugins_path}\"")
   end
 
   def plist_manual

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -61,8 +61,6 @@ class BuildkiteAgent < Formula
   end
 
   def install
-    bin.mkpath
-
     agent_etc.mkpath
     agent_var.mkpath
     pkgshare.mkpath

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -103,6 +103,34 @@ class BuildkiteAgent < Formula
     "buildkite-agent start"
   end
 
+  def caveats
+    <<-EOS.undent
+      \033[32mbuildkite-agent is now installed!\033[0m#{agent_token_reminder}
+
+      Configuration file (to configure agent meta-data, priority, name, etc):
+          #{agent_config_path}
+
+      Hooks directory (for customising the agent):
+          #{agent_hooks_path}
+
+      Builds directory:
+          #{agent_builds_path}
+
+      Log paths:
+          #{var}/log/buildkite-agent.log
+          #{var}/log/buildkite-agent.error.log
+
+      If you set up the LaunchAgent, set your machine to auto-login as
+      your current user. It's also recommended to install Caffeine
+      (http://lightheadsw.com/caffeine/) to prevent your machine from going to
+      sleep or logging out.
+
+      To run multiple agents simply run the buildkite-agent start command
+      multiple times, or duplicate the LaunchAgent plist to create another
+      that starts on login.
+    EOS
+  end
+
   def plist
     <<-EOS.undent
       <?xml version="1.0" encoding="UTF-8"?>
@@ -149,34 +177,6 @@ class BuildkiteAgent < Formula
         <string>#{var}/log/buildkite-agent.error.log</string>
       </dict>
       </plist>
-    EOS
-  end
-
-  def caveats
-    <<-EOS.undent
-      \033[32mbuildkite-agent is now installed!\033[0m#{agent_token_reminder}
-
-      Configuration file (to configure agent meta-data, priority, name, etc):
-          #{agent_config_path}
-
-      Hooks directory (for customising the agent):
-          #{agent_hooks_path}
-
-      Builds directory:
-          #{agent_builds_path}
-
-      Log paths:
-          #{var}/log/buildkite-agent.log
-          #{var}/log/buildkite-agent.error.log
-
-      If you set up the LaunchAgent, set your machine to auto-login as
-      your current user. It's also recommended to install Caffeine
-      (http://lightheadsw.com/caffeine/) to prevent your machine from going to
-      sleep or logging out.
-
-      To run multiple agents simply run the buildkite-agent start command
-      multiple times, or duplicate the LaunchAgent plist to create another
-      that starts on login.
     EOS
   end
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -93,10 +93,6 @@ class BuildkiteAgent < Formula
         .gsub(/plugins-path=.+/, "plugins-path=\"#{agent_plugins_path}\"")
   end
 
-  def plist_manual
-    "buildkite-agent start"
-  end
-
   def caveats
     <<-EOS.undent
       \033[32mbuildkite-agent is now installed!\033[0m#{agent_token_reminder}
@@ -124,6 +120,8 @@ class BuildkiteAgent < Formula
       that starts on login.
     EOS
   end
+
+  plist_options :manual => "buildkite-agent start"
 
   def plist
     <<-EOS.undent

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -1,4 +1,5 @@
 class BuildkiteAgent < Formula
+  desc "Build runner for use with Buildkite"
   homepage "https://buildkite.com/docs/agent"
 
   stable do


### PR DESCRIPTION
I noticed a bug where the formula's caveats couldn't be printed before the formula's installed, since they unconditionally tried reading a file on disk. Since `#caveats` is evaluated by a number of commands, including `brew info`, it's helpful for this to work.

Aside from that, this PR has a whole slew of stylistic fixes, mostly based on the output of `brew audit`/`brew style`. A few of them are bringing things in line with newer Homebrew conventions.