### PR TITLE
Update plist StandardErrorPath to match StandardOutPath

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -166,7 +166,7 @@ class BuildkiteAgent < Formula
         <string>#{var}/log/buildkite-agent.log</string>
 
         <key>StandardErrorPath</key>
-        <string>#{var}/log/buildkite-agent.error.log</string>
+        <string>#{var}/log/buildkite-agent.log</string>
       </dict>
       </plist>
     EOS


### PR DESCRIPTION
Buildkite agent logs all output to stderr.
This means non-error messages also go to stderr which would be buildkite-agent.error.log and this could be confusing.

This change means all log messages go to buildkite-agent.log