### PR TITLE
Don't restart the agent via launchd on successful exit

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -154,7 +154,10 @@ class BuildkiteAgent < Formula
         <true/>
 
         <key>KeepAlive</key>
-        <true/>
+        <dict>
+          <key>SuccessfulExit</key>
+          <true/>
+        </dict>
 
         <key>ProcessType</key>
         <string>Interactive</string>

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -156,7 +156,7 @@ class BuildkiteAgent < Formula
         <key>KeepAlive</key>
         <dict>
           <key>SuccessfulExit</key>
-          <true/>
+          <false/>
         </dict>
 
         <key>ProcessType</key>


### PR DESCRIPTION
Otherwise stopping the agent via the UI won't work. This is the same behaviour as we have in systemd and initd. 

See http://www.launchd.info/#/key-KeepAlive for more context, example at https://github.com/tjluoma/launchd-keepalive#keepalive-and-successfulexit