### PR TITLE
Fix Homebrew directory path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use the formulae, tap this repository into your home brew:
 brew tap buildkite/buildkite
 ```
 
-This repository will have been cloned into your Homebrew’s `Libray/Taps` directory (most commonly `/opt/local/Library/Taps`), and whenever you do a `brew update` Homebrew will also update this tap (using `git pull`) and you’ll have the latest versions of the formulae.
+This repository will have been cloned into your Homebrew’s `Libray/Taps` directory (most commonly `/usr/local/Homebrew/Library/Taps`), and whenever you do a `brew update` Homebrew will also update this tap (using `git pull`) and you’ll have the latest versions of the formulae.
 
 ## buildkite-agent
 


### PR DESCRIPTION
The directory listed here is a bit out of date, it's commonly `/usr/local/Homebrew/Library/Taps`