### PR TITLE
Update agent formula to choose an m1/intel tarball based on the host computer

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -4,7 +4,7 @@ class BuildkiteAgent < Formula
 
   stable do
     version "3.26.0"
-    if Hardware::CPU.physical_cpu_arm64?
+    if Hardware::CPU.arm?
       url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-arm64-3.26.0.tar.gz"
       sha256  "92d731d04912b3de0eb03fe849a0f9eb75554c22ca538a5f388ce3cc66f923e8"
     else

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -4,8 +4,13 @@ class BuildkiteAgent < Formula
 
   stable do
     version "3.26.0"
-    url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-amd64-3.26.0.tar.gz"
-    sha256  "8a2f78aad0791ebe41a546a6c17b71560852a439ba311d541d63073410645b2d"
+    if Hardware::CPU.physical_cpu_arm64?
+      url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-arm64-3.26.0.tar.gz"
+      sha256  "92d731d04912b3de0eb03fe849a0f9eb75554c22ca538a5f388ce3cc66f923e8"
+    else
+      url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-amd64-3.26.0.tar.gz"
+      sha256  "8a2f78aad0791ebe41a546a6c17b71560852a439ba311d541d63073410645b2d"
+    end
   end
 
   def agent_etc


### PR DESCRIPTION
Homebrew is working through the complexity of transitioning from Intel to Apple Silicon and much is up in the air.

However, our agent formula is quite simple. On Apple Silicon machines, we can ignore whether homebrew itself is running natively and just always download the Apple Silicon version of the agent.

On non Apple Silicon machines, we can ignore whether homebrew itself is running natively and just always download the Intel version of the agent.

This requires some helpers added to homebrew in https://github.com/Homebrew/brew/pull/7995. Will they be available everywhere?

Before merging this we also need to consider the agent CD scripts that update this file automatically: https://github.com/buildkite/agent/blob/b2cf4e3d90f5b155505ec6eb53e007a4d88239d7/.buildkite/steps/release-homebrew.sh