### PR TITLE
Replace plist heredoc with service

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -114,58 +114,17 @@ class BuildkiteAgent < Formula
     EOS
   end
 
-  plist_options :manual => "buildkite-agent start"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-
-        <key>WorkingDirectory</key>
-        <string>#{HOMEBREW_PREFIX}/bin</string>
-
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{HOMEBREW_PREFIX}/bin/buildkite-agent</string>
-          <string>start</string>
-          <string>--config</string>
-          <string>#{agent_config_path}</string>
-          <!--<string>--debug</string>-->
-        </array>
-
-        <key>EnvironmentVariables</key>
-        <dict>
-          <key>PATH</key>
-          <string>#{HOMEBREW_PREFIX}/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        </dict>
-
-        <key>RunAtLoad</key>
-        <true/>
-
-        <key>KeepAlive</key>
-        <dict>
-          <key>SuccessfulExit</key>
-          <false/>
-        </dict>
-
-        <key>ProcessType</key>
-        <string>Interactive</string>
-
-        <key>ThrottleInterval</key>
-        <integer>30</integer>
-
-        <key>StandardOutPath</key>
-        <string>#{var}/log/buildkite-agent.log</string>
-
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/buildkite-agent.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [
+      HOMEBREW_PREFIX/"bin/buildkite-agent", "start", 
+        "--config", etc/"buildkite-agent/buildkite-agent.cfg"
+    ]
+    working_dir HOMEBREW_PREFIX/"bin"   # Why?
+    keep_alive successful_exit: false
+    environment_variables PATH: HOMEBREW_PREFIX/"bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    process_type :interactive
+    log_path var/"log/buildkite-agent.log"
+    error_log_path var/"log/buildkite-agent.log"
   end
 
   test do


### PR DESCRIPTION
This is the (new) way.

Differences in the output plist:

* `ThrottleInterval: 30` is gone. I can't see how to add it with the new service thing. I can't see a rationale for 30 anywhere in the commit history. I assume it was copied from an example somewhere.
* There's a new `LimitLoadToSessionType` thing, which I assume is a sensible default chosen by the Homebrew folks.

This also removes `plist_options`, which is deprecated. I can't see a substitute (I think it's responsible for the line after "Or, if you don't want/need a background service you can just run:" in the post-install output? Homebrew seem to have removed the documentation for `plist_options`) but the new output is at least correct.

Fixes #30