### PR TITLE
test-splitter 0.7.2

### DIFF
--- a/test-splitter.rb
+++ b/test-splitter.rb
@@ -2,13 +2,13 @@ class TestSplitter < Formula
   desc "Buildkite test splitting client"
   homepage "https://github.com/buildkite/test-splitter"
 
-  version "0.7.0"
+  version "0.7.1"
   if Hardware::CPU.arm?
-    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.0/test-splitter-darwin-arm64"
-    sha256 "d651ee82885675f57cab6eef3f82980b0c3e554af1f92f2aff9ec31177482b56"
+    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.1/test-splitter-darwin-arm64"
+    sha256 "f67dda69a3e2b15dc5f2d0a6aa5bde71b4b0526b918eaaef9746af57218af4f2"
   else
-    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.0/test-splitter-darwin-amd64"
-    sha256 "f6fa9f54652921c21b650514d21747a81557df83a711b354508a75331ad555ca"
+    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.1/test-splitter-darwin-amd64"
+    sha256 "2af04832cb323bd5b10dba4d7334908cf9ceefa185fb0866ebbb90149f17d599"
   end
 
   def install
@@ -20,10 +20,6 @@ class TestSplitter < Formula
   end
 
   test do
-    # We should be able to do this, but it currently fails
-    # https://github.com/buildkite/test-splitter/issues/106
-    # system "test-splitter", "--version"
-
-    assert_predicate bin/"test-splitter", :executable?
+    system "test-splitter", "--version"
   end
 end

--- a/test-splitter.rb
+++ b/test-splitter.rb
@@ -1,0 +1,29 @@
+class TestSplitter < Formula
+  desc "Buildkite test splitting client"
+  homepage "https://github.com/buildkite/test-splitter"
+
+  version "0.7.0"
+  if Hardware::CPU.arm?
+    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.0/test-splitter-darwin-arm64"
+    sha256 "d651ee82885675f57cab6eef3f82980b0c3e554af1f92f2aff9ec31177482b56"
+  else
+    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.0/test-splitter-darwin-amd64"
+    sha256 "f6fa9f54652921c21b650514d21747a81557df83a711b354508a75331ad555ca"
+  end
+
+  def install
+    if Hardware::CPU.arm?
+      bin.install "test-splitter-darwin-arm64" => "test-splitter"
+    else
+      bin.install "test-splitter-darwin-amd64" => "test-splitter"
+    end
+  end
+
+  test do
+    # We should be able to do this, but it currently fails
+    # https://github.com/buildkite/test-splitter/issues/106
+    # system "test-splitter", "--version"
+
+    assert_predicate bin/"test-splitter", :executable?
+  end
+end

--- a/test-splitter.rb
+++ b/test-splitter.rb
@@ -20,6 +20,7 @@ class TestSplitter < Formula
   end
 
   test do
-    system "test-splitter", "--version"
+    version_output = shell_output("test-splitter --version")
+    assert_match "v0.7.2\n", version_output
   end
 end

--- a/test-splitter.rb
+++ b/test-splitter.rb
@@ -2,13 +2,13 @@ class TestSplitter < Formula
   desc "Buildkite test splitting client"
   homepage "https://github.com/buildkite/test-splitter"
 
-  version "0.7.1"
+  version "0.7.2"
   if Hardware::CPU.arm?
-    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.1/test-splitter-darwin-arm64"
-    sha256 "f67dda69a3e2b15dc5f2d0a6aa5bde71b4b0526b918eaaef9746af57218af4f2"
+    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.2/test-splitter-darwin-arm64"
+    sha256 "7d800fd40ef6dc22c04b0cc373780f5b6b15c3c9f342678fbf7850152121a592"
   else
-    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.1/test-splitter-darwin-amd64"
-    sha256 "2af04832cb323bd5b10dba4d7334908cf9ceefa185fb0866ebbb90149f17d599"
+    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.2/test-splitter-darwin-amd64"
+    sha256 "ede9678b2994eb6a7f1b25f5d1650b0c922f94f27f2a0c6b2688606d14dd3f3e"
   end
 
   def install


### PR DESCRIPTION
Add https://github.com/buildkite/test-splitter to homebrew so folks can install and use it easily on macOS:

```
brew install buildkite/buildkite/test-splitter
```