### PR TITLE
Upgrade test-splitter to v0.7.3.

### DIFF
--- a/test-splitter.rb
+++ b/test-splitter.rb
@@ -2,13 +2,13 @@ class TestSplitter < Formula
   desc "Buildkite test splitting client"
   homepage "https://github.com/buildkite/test-splitter"
 
-  version "0.7.2"
+  version "0.7.3"
   if Hardware::CPU.arm?
-    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.2/test-splitter-darwin-arm64"
-    sha256 "7d800fd40ef6dc22c04b0cc373780f5b6b15c3c9f342678fbf7850152121a592"
+    url "https://github.com/buildkite/test-splitter/releases/download/v#{version}/test-splitter-darwin-arm64"
+    sha256 "df437cfae7218c436a4ab71ad92cbbf1a00ff20c6f33cfc5fe4ac51c300af08c"
   else
-    url "https://github.com/buildkite/test-splitter/releases/download/v0.7.2/test-splitter-darwin-amd64"
-    sha256 "ede9678b2994eb6a7f1b25f5d1650b0c922f94f27f2a0c6b2688606d14dd3f3e"
+    url "https://github.com/buildkite/test-splitter/releases/download/v#{version}/test-splitter-darwin-amd64"
+    sha256 "09c14438b7e44296ea27f8622a65dd62747a959678a9ccc28b2e1a4516da7b2f"
   end
 
   def install
@@ -21,6 +21,6 @@ class TestSplitter < Formula
 
   test do
     version_output = shell_output("test-splitter --version")
-    assert_match "v0.7.2\n", version_output
+    assert_match "v#{version}\n", version_output
   end
 end


### PR DESCRIPTION
I've also tidied up around the version string so we only have to update it in one place.