### PR TITLE
Point default cli to v3

### DIFF
--- a/bk@3.rb
+++ b/bk@3.rb
@@ -62,8 +62,6 @@ class BkAT3 < Formula
 
   def caveats
     <<~EOS
-      This is beta software
-
       For any questions, issues or feedback, please file an issue at https://github.com/buildkite/cli/issues
     EOS
   end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,5 +1,5 @@
 {
-  "bk": "bk@2",
-  "buildkite-cli": "bk@2",
-  "cli": "bk@2"
+  "bk": "bk@3",
+  "buildkite-cli": "bk@3",
+  "cli": "bk@3"
 }


### PR DESCRIPTION
Prepare to go GA for BK CLI v3.0 by making the default install target v3.0

v2.0 is still installable directly with `brew install bk@2`
