### PR TITLE
fix: Set a default name to cater for the version split

### DIFF
--- a/Formula/buildkite-agent@3.rb
+++ b/Formula/buildkite-agent@3.rb
@@ -118,6 +118,12 @@ class BuildkiteAgentAT3 < Formula
   end
 
   service do
+    # Pin the launchd plist name to the pre-rename label so existing service
+    # registrations and tooling that reference `homebrew.mxcl.buildkite-agent`
+    # keep working after the rename to `buildkite-agent@3`. Without this, the
+    # default plist name would become `homebrew.mxcl.buildkite-agent@3`, which
+    # breaks migrations from the previous unversioned formula (see A-1338).
+    name macos: "homebrew.mxcl.buildkite-agent"
     run [
       HOMEBREW_PREFIX/"bin/buildkite-agent", "start",
         "--config", etc/"buildkite-agent/buildkite-agent.cfg"


### PR DESCRIPTION
After the `buildkite-agent` to `buildkite-agent@3` rename in #54, `brew services start buildkite/buildkite/buildkite-agent` fails on machines that had the old formula installed -

```
Error: Invalid usage: Formula 'buildkite-agent@3' has not implemented #plist, #service or provided a locatable service file.
```

`brew update` migrates the Cellar dir but doesn't regenerate the plist. The on-disk plist is still named `homebrew.mxcl.buildkite-agent.plist`, but `brew services` now looks for `homebrew.mxcl.buildkite-agent@3.plist`.

Fix: pin the launchd label via [name macos:](https://docs.brew.sh/Formula-Cookbook#service-files) so generated and pre-existing plist names match, and existing launchd registrations keep working.

Verified:

```
$ brew ruby -e 'puts Formulary.factory("buildkite/buildkite/buildkite-agent@3").plist_name'
homebrew.mxcl.buildkite-agent
```

Recovery for affected hosts: `brew upgrade buildkite-agent@3 && brew services start buildkite-agent@3`.

Resolves A-1338